### PR TITLE
Change default implementation of IsolationForest to coniferest one

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import setuptools
 setuptools.setup(name='zwad',
                  packages=['zwad'],
                  install_requires=[
+                     'coniferest @ git+https://github.com/snad-space/coniferest.git@de3112ab0f2b5bea5d7d33887b2e119b1476840e#egg=coniferest-0.0.2',
                      'pandas<2.0',
                      'click',
                      'pillow',

--- a/zwad/ad/__init__.py
+++ b/zwad/ad/__init__.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from sklearn.mixture import GaussianMixture
 from sklearn.neighbors import LocalOutlierFactor
 from sklearn.svm import OneClassSVM
-from sklearn.ensemble import IsolationForest
+from coniferest.isoforest import IsolationForest
 
 from zwad.ad.preprocess import scale_values
 from zwad.ad.postprocess import save_anomaly_list
@@ -23,7 +23,7 @@ class BaseAnomalyDetector(ABC):
         'gmm': GaussianMixture(n_components=10, covariance_type='spherical', n_init=15),
         'svm': OneClassSVM(gamma='scale', nu=0.02, kernel='rbf'),
         'lof': LocalOutlierFactor(n_neighbors=100, contamination=0.02, algorithm='kd_tree', metric='euclidean'),
-        'iso': IsolationForest(max_samples=1000, contamination='auto', n_estimators=1000),
+        'iso': IsolationForest(n_subsamples=1024, n_trees=3000),
     }
 
     def __init__(self, args=None):


### PR DESCRIPTION
You know what I want. It also changes number of estimators according to [dr4 experiments](https://github.com/snad-space/ztf-dr4/blob/main/static/n_trees/n_trees.ipynb) with number of trees. The experiments show that we need 3000 threes for dr4 data in order for anomalies to be 90% representative. I guess we should not use less at default.